### PR TITLE
controllers: tcpip: use shutdown instead of close

### DIFF
--- a/controllers/tcpip.c
+++ b/controllers/tcpip.c
@@ -92,7 +92,10 @@ static int tcpip_connection_destroy(struct connection *conn)
 	struct tcpip_connection *tconn = conn->priv;
 
 	conn->priv = NULL;
-	close(tconn->sock);
+	pr_info("closing socket %d\n", tconn->sock);
+	if (shutdown(tconn->sock, SHUT_RDWR)) {
+		pr_err("failed to close socket %d\n", tconn->sock);
+	}
 	free(tconn);
 
 	return 0;


### PR DESCRIPTION
When close(fd) is used on the a TCP/IP socket in Linux, it puts the socket into a FIN_WAIT1 state and the TCP/IP connection is not completely severed until the application terminates. On the server side, this has the effect of keeping sockets open for an unnecessarily long period of time. If the server is a memory-contstrained device such as a microcontroller, that can have very negative effects.

For that reason, it is preferred to use shutdown(fd, SHUT_RDWR) instead.